### PR TITLE
ci: publish to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+
+      - name: Publish to GitHub Packages
+        run: mvn --batch-mode deploy -D spring-boot.repackage.skip=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,14 @@
 		<kotlin.version>2.2.21</kotlin.version>
 	</properties>
 
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/TheKorrent/Korrent</url>
+        </repository>
+    </distributionManagement>
+
 	<dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Close #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated publishing of build artifacts to GitHub Packages when a release is created.
  * Added a release-triggered CI workflow that sets up Java and runs a Maven deploy step to publish artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->