### PR TITLE
ci: publish to Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Java
+      - name: Setup Java for GitHub Packages
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -25,3 +25,21 @@ jobs:
         run: mvn --batch-mode deploy -D spring-boot.repackage.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Java for Maven Central
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+          server-id: central
+          server-username: ${{ secrets.SERVER_USERNAME }}
+          server-password: ${{ secrets.SERVER_PASSWORD }}
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish to Maven Central
+        run: mvn deploy -D spring-boot.repackage.skip=true
+        env:
+          SERVER_USERNAME: ${{ secrets.SERVER_USERNAME }}
+          SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Build
         run: mvn clean package
 
+      - name: Clean
+        run: |
+          rm target/*-javadoc.jar
+          rm target/*-sources.jar
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Clean
         run: |
-          rm target/*-javadoc.jar
-          rm target/*-sources.jar
+          rm -f target/*-javadoc.jar
+          rm -f target/*-sources.jar
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,31 @@
 	<groupId>moe.shizuki.korrent</groupId>
 	<artifactId>korrent</artifactId>
 	<version>0.1.0</version>
+
 	<name>Korrent</name>
+    <description>Korrent</description>
+    <url>https://github.com/TheKorrent/Korrent</url>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License version 3</name>
+            <url>https://opensource.org/license/gpl-3-0</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Shizuki Natsuki</name>
+            <email>shizuki.natsuki@outlook.com</email>
+            <url>https://shizuki.moe</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/TheKorrent/Korrent.git</connection>
+        <developerConnection>scm:git:ssh://github.com:TheKorrent/Korrent.git</developerConnection>
+        <url>https://github.com/TheKorrent/Korrent</url>
+    </scm>
 
 	<properties>
 		<java.version>21</java.version>
@@ -131,6 +155,74 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>2.1.0</version>
+
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.6</version>
+                <inherited>false</inherited>
+
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Close: #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled publishing to Maven Central with cryptographic artifact signing and automated deploy steps.
  * Added project metadata (name, description, URL, license, developers, SCM) for better discoverability.
  * Configured automated generation and packaging of source and API documentation.
  * Updated release workflows to clean and ensure only runtime artifacts are published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->