### PR TITLE
feat: add schedule configuration

### DIFF
--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/client/BitTorrentClient.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/client/BitTorrentClient.kt
@@ -1,11 +1,13 @@
 package moe.shizuki.korrent.bittorrent.client
 
-import moe.shizuki.korrent.bittorrent.model.BitTorrentClientInfo
+import moe.shizuki.korrent.bittorrent.config.BitTorrentConfig
+import moe.shizuki.korrent.bittorrent.model.BitTorrentClientType
 import moe.shizuki.korrent.plugin.config.PluginConfigManager
 import moe.shizuki.korrent.plugin.data.PluginDataManager
 
 abstract class BitTorrentClient {
-    abstract val clientInfo: BitTorrentClientInfo
+    abstract val clientType: BitTorrentClientType
+    abstract val clientConfig: BitTorrentConfig
 
     val pluginConfigManager: PluginConfigManager = PluginConfigManager()
     val pluginDataManager = PluginDataManager()

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/client/QBittorrentClient.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/client/QBittorrentClient.kt
@@ -1,5 +1,6 @@
 package moe.shizuki.korrent.bittorrent.client
 
+import moe.shizuki.korrent.bittorrent.config.QBittorrentConfig
 import moe.shizuki.korrent.bittorrent.model.*
 import moe.shizuki.korrent.bittorrent.service.QBittorrentService
 import moe.shizuki.korrent.objectMapper
@@ -17,13 +18,12 @@ import java.net.CookieManager
 import java.net.CookiePolicy
 
 class QBittorrentClient(
-    val name: String,
-    val baseUrl: String,
-
+    val config: QBittorrentConfig
 ): BitTorrentClient() {
     private val service: QBittorrentService
 
-    override val clientInfo = BitTorrentClientInfo(BitTorrentClientType.QBITTORRENT, name, baseUrl)
+    override val clientType = BitTorrentClientType.QBITTORRENT
+    override val clientConfig = config
 
     init {
         val cookieManager = CookieManager().apply {
@@ -35,7 +35,7 @@ class QBittorrentClient(
             .build()
 
         val retrofit = Retrofit.Builder()
-            .baseUrl(baseUrl)
+            .baseUrl(config.common.baseUrl)
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(JacksonConverterFactory.create(objectMapper))
             .client(client)

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
@@ -4,6 +4,8 @@ data class BitTorrentCommonConfig(
     val name: String,
     val baseUrl: String,
     val polling: Polling
-) class Polling(
-    val schedule: String
-)
+) {
+    class Polling(
+        val schedule: String
+    )
+}

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
@@ -3,4 +3,7 @@ package moe.shizuki.korrent.bittorrent.config
 data class BitTorrentCommonConfig(
     val name: String,
     val baseUrl: String,
+    val polling: Polling
+) class Polling(
+    val schedule: String
 )

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentConfig.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentConfig.kt
@@ -1,0 +1,5 @@
+package moe.shizuki.korrent.bittorrent.config
+
+open class BitTorrentConfig(
+    open val common: BitTorrentCommonConfig
+)

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentConfigManager.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentConfigManager.kt
@@ -40,7 +40,7 @@ class BitTorrentConfigManager {
             val config = get(QBittorrentConfig::class.java)
 
             if (config is QBittorrentConfig) {
-                val client = QBittorrentClient(config.common.name, config.common.baseUrl)
+                val client = QBittorrentClient(config)
 
                 client.login(config.qbittorrent.username, config.qbittorrent.password).execute()
                 clientManager.add(client)

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/QBittorrentConfig.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/QBittorrentConfig.kt
@@ -1,10 +1,10 @@
 package moe.shizuki.korrent.bittorrent.config
 
-data class QBittorrentConfig(
-    val common: BitTorrentCommonConfig,
-    val qbittorrent: Config
-) {
-    data class Config(
+class QBittorrentConfig(
+    override val common: BitTorrentCommonConfig,
+    val qbittorrent: QBittorrent
+): BitTorrentConfig(common) {
+    data class QBittorrent(
         val username: String,
         val password: String
     )

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/model/BitTorrentClientInfo.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/model/BitTorrentClientInfo.kt
@@ -1,7 +1,5 @@
 package moe.shizuki.korrent.bittorrent.model
 
 data class BitTorrentClientInfo(
-    val client: BitTorrentClientType,
-    val name: String,
-    val baseUrl: String
+    val client: BitTorrentClientType
 )

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/task/QBittorrentScheduleTask.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/task/QBittorrentScheduleTask.kt
@@ -26,7 +26,7 @@ class QBittorrentScheduleTask {
             {
                 publisher.polling(client)
             },
-            CronTrigger("*/5 * * * * *")
+            CronTrigger(client.clientConfig.common.polling.schedule)
         )
     }
 

--- a/src/main/kotlin/moe/shizuki/korrent/web/controller/ClientController.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/web/controller/ClientController.kt
@@ -1,6 +1,6 @@
 package moe.shizuki.korrent.web.controller
 
-import moe.shizuki.korrent.bittorrent.model.BitTorrentClientInfo
+import moe.shizuki.korrent.bittorrent.config.BitTorrentConfig
 import moe.shizuki.korrent.web.model.ResponseData
 import moe.shizuki.korrent.web.service.ClientService
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,7 +21,7 @@ class ClientController {
     }
 
     @GetMapping
-    fun getClient(): ResponseData<BitTorrentClientInfo> {
+    fun getClient(): ResponseData<BitTorrentConfig> {
         return ResponseData(HttpStatus.OK.value(), "Get client successful", service.getClient())
     }
 

--- a/src/main/kotlin/moe/shizuki/korrent/web/service/ClientService.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/web/service/ClientService.kt
@@ -1,8 +1,8 @@
 package moe.shizuki.korrent.web.service
 
 import moe.shizuki.korrent.bittorrent.client.BitTorrentClientManager
+import moe.shizuki.korrent.bittorrent.config.BitTorrentConfig
 import moe.shizuki.korrent.bittorrent.config.BitTorrentConfigManager
-import moe.shizuki.korrent.bittorrent.model.BitTorrentClientInfo
 import moe.shizuki.korrent.web.exception.ClientAlreadyExistsException
 import moe.shizuki.korrent.web.exception.ClientNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,8 +25,8 @@ class ClientService {
         configManager.load()
     }
 
-    fun getClient(): BitTorrentClientInfo {
-        return clientManager.get()?.clientInfo ?: throw ClientNotFoundException("Client not found")
+    fun getClient(): BitTorrentConfig {
+        return clientManager.get()?.clientConfig ?: throw ClientNotFoundException("Client not found")
     }
 
     fun updateClient(client: String) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling schedules are now configurable per client — polling cadence is read from each client's configuration.

* **Configuration Updates**
  * Client configuration model restructured: client identity and connection details are exposed via a richer config object, and the client-facing API now returns client configuration data instead of the previous compact info view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->