### PR TITLE
feat: add plugin data manager

### DIFF
--- a/src/main/kotlin/moe/shizuki/korrent/plugin/KorrentPlugin.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/plugin/KorrentPlugin.kt
@@ -4,11 +4,13 @@ import moe.shizuki.korrent.plugin.annotation.processor.KorrentConfigProcessor
 import moe.shizuki.korrent.plugin.annotation.processor.KorrentEventProcessor
 import moe.shizuki.korrent.plugin.annotation.processor.KorrentScheduleEventProcessor
 import moe.shizuki.korrent.plugin.config.PluginConfigManager
+import moe.shizuki.korrent.plugin.data.PluginDataManager
 import org.pf4j.Plugin
 import org.pf4j.PluginWrapper
 
 abstract class KorrentPlugin(wrapper: PluginWrapper): Plugin(wrapper) {
     val pluginConfigManager = PluginConfigManager(wrapper.pluginId)
+    val pluginDataManager = PluginDataManager(wrapper.pluginId)
 
     override fun start() {
         super.start()

--- a/src/main/kotlin/moe/shizuki/korrent/plugin/data/PluginDataManager.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/plugin/data/PluginDataManager.kt
@@ -8,4 +8,9 @@ class PluginDataManager(
 ) {
     val pluginDataFolder = File(moe.shizuki.korrent.pluginDataFolder, id)
     val pluginCacheFolder = File(cacheFolder, "plugins${File.separator}$id")
+
+    init {
+        pluginDataFolder.mkdirs()
+        pluginCacheFolder.mkdirs()
+    }
 }

--- a/src/main/kotlin/moe/shizuki/korrent/plugin/data/PluginDataManager.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/plugin/data/PluginDataManager.kt
@@ -1,0 +1,11 @@
+package moe.shizuki.korrent.plugin.data
+
+import moe.shizuki.korrent.cacheFolder
+import java.io.File
+
+class PluginDataManager(
+    private val id: String
+) {
+    val pluginDataFolder = File(moe.shizuki.korrent.pluginDataFolder, id)
+    val pluginCacheFolder = File(cacheFolder, "plugins${File.separator}$id")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins now have a dedicated data manager providing per-plugin storage and a separate plugin cache location.
  * The plugin instance exposes this manager so plugin data and cache are available without changing startup/shutdown behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->