### PR TITLE
refactor: rename cron to schedule

### DIFF
--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/config/BitTorrentCommonConfig.kt
@@ -7,7 +7,7 @@ data class BitTorrentCommonConfig(
     val proxy: Proxy = Proxy()
 ) {
     class Polling(
-        val cron: String = "*/5 * * * * *"
+        val schedule: String = "*/5 * * * * *"
     )
 
     class Proxy(

--- a/src/main/kotlin/moe/shizuki/korrent/bittorrent/task/QBittorrentScheduleTask.kt
+++ b/src/main/kotlin/moe/shizuki/korrent/bittorrent/task/QBittorrentScheduleTask.kt
@@ -4,7 +4,6 @@ import com.google.common.eventbus.EventBus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import moe.shizuki.korrent.bittorrent.client.call.QBittorrentClient
 import moe.shizuki.korrent.bittorrent.event.QBittorrentEventPublisher
-import moe.shizuki.korrent.clientConfigFile
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.support.CronTrigger
@@ -30,10 +29,10 @@ class QBittorrentScheduleTask {
             {
                 publisher.polling(client)
             },
-            CronTrigger(client.config.common.polling.cron)
+            CronTrigger(client.config.common.polling.schedule)
         )
 
-        logger.info { "Client [${client.config.common.name}] registered [${client.config.common.polling.cron}]" }
+        logger.info { "Client [${client.config.common.name}] registered [${client.config.common.polling.schedule}]" }
     }
 
     fun remove(clientName: String) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed configuration property from `cron` to `schedule` in polling settings. Users with manually configured polling settings must update their configuration files to use the new property name. The default behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->